### PR TITLE
expanded to support all languages supported by protoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>com.github.igor-petruk.protobuf</groupId>
     <artifactId>protobuf-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.6.4-SNAPSHOT</version>
     <name>Maven Protobuf Plugin</name>
     <description>Maven Plugin to compile Google Protobuf Messsage files</description>
     <url>http://igor-petruk.github.com/protobuf-maven-plugin/</url>


### PR DESCRIPTION
Hi, I've modified the mojo slightly to also support C++ and Python output in the configuration section of the pom (example below). They are set to false by default. The Java output remains defaulted to true. So, there should be no backward compatibility issues for users. I also bumped the version to 0.6.5-SNAPSHOT because this represents an enhancement.

This modification is very useful. One of the purposes of proto buffers is the ability to de/serialize across languages. My project, for instance, requires a C++ and a Java application to share network messages. In order to do this seamlessly, we use proto buffers and auto-compile to both Java and C++. With your maven plugin and my modifications, the compile process is as simple as 'mvn compile'. Thanks for making a very useful maven plugin.

Example usage for all three output types at once:

```
                   <plugin>
            <groupId>com.github.igor-petruk.protobuf</groupId>
            <artifactId>protobuf-maven-plugin</artifactId>
            <version>0.6.5-SNAPSHOT</version>
            <executions>
                <execution>
                    <configuration>
                        <javaOuput>true</javaOuput>
                        <cppOutput>true</cppOutput>
                        <pythonOuput>true</pythonOuput>
                    </configuration>
                    <goals>
                        <goal>run</goal>
                    </goals>
                </execution>
            </executions>
        </plugin>
```
