### PR TITLE
Add Maven Central status to readme badge

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,0 @@
-Hello.
-
-There are a couple of plugins out there to compile
-Google Protobuf files, but most of them end up
-giving NPEs, so you have to fallback to Exec Plugin.
-
-That's why I wanted to create a quite simple plugin
-that just does the job. Plus the source code is very
-small and simple to fix any possible issue.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.igor-petruk.protobuf/protobuf-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.igor-petruk.protobuf/protobuf-maven-plugin)
+
+Hello.
+
+There are a couple of plugins out there to compile
+Google Protobuf files, but most of them end up
+giving NPEs, so you have to fallback to Exec Plugin.
+
+That's why I wanted to create a quite simple plugin
+that just does the job. Plus the source code is very
+small and simple to fix any possible issue.


### PR DESCRIPTION
This may help users find the latest artifact in Maven Central.

This also renames the readme to markdown format so that the badge is rendered nicely on github.
